### PR TITLE
Add CORS configuration from ini, similar to WebGnomeAPI

### DIFF
--- a/development.ini
+++ b/development.ini
@@ -15,6 +15,9 @@ pyramid.default_locale_name = en
 pyramid.includes = pyramid_tm
                    cornice
 
+cors_policy.origins = http://0.0.0.0:8080
+                      http://localhost:8080
+
 [pipeline:main]
 pipeline =
     gzip

--- a/oil_library_api/__init__.py
+++ b/oil_library_api/__init__.py
@@ -4,12 +4,21 @@ import logging
 logging.basicConfig()
 
 from pyramid.config import Configurator
+from oil_library_api.common.views import cors_policy
 
+def load_cors_origins(settings, key):
+    if key in settings:
+        origins = settings[key].split('\n')
+        cors_policy['origins'] = origins
 
 def main(global_config, **settings):
+
+    load_cors_origins(settings, 'cors_policy.origins')
+
     config = Configurator(settings=settings)
 
     config.include("cornice")
     config.include('pyramid_mako')
     config.scan("oil_library_api.views")
     return config.make_wsgi_app()
+

--- a/oil_library_api/common/views.py
+++ b/oil_library_api/common/views.py
@@ -2,14 +2,7 @@
 Common Gnome object request handlers.
 """
 
-cors_policy = {'origins': (
-                           'http://0.0.0.0:8080',
-                           'http://localhost:8080',
-                           'http://hazweb2.orr.noaa.gov:7448'
-                           ),
-               'credentials': True
-               }
-
+cors_policy = {'credentials': True}
 
 def obj_id_from_url(request):
     # the pyramid URL parser returns a tuple of 0 or more

--- a/production.ini
+++ b/production.ini
@@ -15,6 +15,8 @@ pyramid.default_locale_name = en
 pyramid.includes = pyramid_tm
                    cornice
 
+cors_policy.origins = http://hazweb2.orr.noaa.gov:7448
+
 [server:main]
 use = egg:waitress#main
 host = 0.0.0.0


### PR DESCRIPTION
I needed to configure CORS for OilLibraryAPI similar to how WebGnomeAPI does it, so I borrowed the code from there.  Let me know if I should adjust development/production differently.
